### PR TITLE
Expose service nodes from smart contract

### DIFF
--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -57,8 +57,6 @@ include(cmake/SourcesAndHeaders.cmake)
 FetchContent_Declare(nlohmann URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
 FetchContent_MakeAvailable(nlohmann)
 
-find_package(Boost 1.62 QUIET REQUIRED COMPONENTS system thread serialization program_options)
-
 add_subdirectory(external)
 
 add_library(

--- a/test/cpp/include/service_node_rewards/ec_utils.hpp
+++ b/test/cpp/include/service_node_rewards/ec_utils.hpp
@@ -16,7 +16,7 @@
 
 namespace utils
 {
-    std::string                   BLSPublicKeyToHex(bls::PublicKey publicKey);
+    std::string                   BLSPublicKeyToHex(const bls::PublicKey& publicKey);
     bls::PublicKey                HexToBLSPublicKey(std::string_view hex);
     std::string                   SignatureToHex(bls::Signature sig);
     std::array<unsigned char, 32> HashModulus(std::string message);

--- a/test/cpp/include/service_node_rewards/ec_utils.hpp
+++ b/test/cpp/include/service_node_rewards/ec_utils.hpp
@@ -16,10 +16,8 @@
 
 namespace utils
 {
-
-    std::string PublicKeyToHex(bls::PublicKey publicKey);
-    std::string SignatureToHex(bls::Signature sig);
+    std::string                   BLSPublicKeyToHex(bls::PublicKey publicKey);
+    bls::PublicKey                HexToBLSPublicKey(std::string_view hex);
+    std::string                   SignatureToHex(bls::Signature sig);
     std::array<unsigned char, 32> HashModulus(std::string message);
-
-// END
 }

--- a/test/cpp/include/service_node_rewards/service_node_list.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_list.hpp
@@ -24,11 +24,10 @@ public:
     uint64_t service_node_id;
     ServiceNode(uint64_t _service_node_id);
     ~ServiceNode();
-    bls::Signature signHash(const std::array<unsigned char, 32>& hash);
-    std::string proofOfPossession(uint32_t chainID, const std::string& contractAddress, const std::string& senderEthAddress, const std::string& serviceNodePubkey);
-    std::string getPublicKeyHex();
-    bls::PublicKey getPublicKey();
-// End Service Node
+    bls::Signature signHash(const std::array<unsigned char, 32>& hash) const;
+    std::string    proofOfPossession(uint32_t chainID, const std::string& contractAddress, const std::string& senderEthAddress, const std::string& serviceNodePubkey);
+    std::string    getPublicKeyHex() const;
+    bls::PublicKey getPublicKey() const;
 };
 
 class ServiceNodeList {

--- a/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <string_view>
 #include <vector>
 #include <memory>
 
@@ -15,18 +16,32 @@ struct Recipient {
     Recipient(uint64_t _rewards, uint64_t _claimed) : rewards(_rewards), claimed(_claimed) {}
 };
 
+struct ContractServiceNode {
+    uint64_t                      next;
+    uint64_t                      prev;
+    std::array<unsigned char, 20> recipient;
+    bls::PublicKey                pubkey;
+    uint64_t                      leaveRequestTimestamp;
+    std::string                   deposit;
+};
+
 class ServiceNodeRewardsContract {
 public:
+    // TODO: Taken from scripts/deploy-local-test.js and hardcoded
+    static constexpr inline uint64_t STAKING_REQUIREMENT = 15'000'000'000'000;
+
     // Constructor
     ServiceNodeRewardsContract(const std::string& _contractAddress, std::shared_ptr<Provider> _provider);
 
     // Method for creating a transaction to add a public key
     Transaction addBLSPublicKey(const std::string& publicKey, const std::string& sig, const std::string& serviceNodePubkey, const std::string& serviceNodeSignature, uint64_t fee);
 
-    uint64_t serviceNodesLength();
-    std::string designatedToken();
-    std::string aggregatePubkey();
-    Recipient viewRecipientData(const std::string& address);
+    ContractServiceNode serviceNodes(uint64_t index);
+    uint64_t            serviceNodeIDs(const bls::PublicKey& pKey);
+    uint64_t            serviceNodesLength();
+    std::string         designatedToken();
+    std::string         aggregatePubkey();
+    Recipient           viewRecipientData(const std::string& address);
 
     Transaction liquidateBLSPublicKeyWithSignature(const uint64_t service_node_id, const std::string& pubkey, const std::string& sig, const std::vector<uint64_t>& non_signer_indices);
     Transaction initiateRemoveBLSPublicKey(const uint64_t service_node_id);

--- a/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
@@ -28,7 +28,7 @@ struct ContractServiceNode {
 class ServiceNodeRewardsContract {
 public:
     // TODO: Taken from scripts/deploy-local-test.js and hardcoded
-    static constexpr inline uint64_t STAKING_REQUIREMENT = 15'000'000'000'000;
+    static constexpr inline uint64_t STAKING_REQUIREMENT = 100'000'000'000;
 
     // Constructor
     ServiceNodeRewardsContract(const std::string& _contractAddress, std::shared_ptr<Provider> _provider);

--- a/test/cpp/src/ec_utils.cpp
+++ b/test/cpp/src/ec_utils.cpp
@@ -1,6 +1,8 @@
 #include "service_node_rewards/ec_utils.hpp"
 #include "ethyl/utils.hpp"
 
+#include <cstring>
+
 std::string utils::SignatureToHex(bls::Signature sig) {
     mclSize serializedSignatureSize = 32;
     std::vector<unsigned char> serialized_signature(serializedSignatureSize*4);
@@ -20,20 +22,90 @@ std::string utils::SignatureToHex(bls::Signature sig) {
     return utils::toHexString(serialized_signature);
 }
 
-std::string utils::PublicKeyToHex(bls::PublicKey publicKey) {
-    mclSize serializedPublicKeySize = 32;
-    std::vector<unsigned char> serialized_pubkey(serializedPublicKeySize*2);
-    uint8_t *dst = serialized_pubkey.data();
-    const blsPublicKey* pub = publicKey.getPtr();  
-    const mcl::bn::G1* g1Point = reinterpret_cast<const mcl::bn::G1*>(&pub->v);
-    mcl::bn::G1 g1Point2 = *g1Point;
+std::string utils::BLSPublicKeyToHex(bls::PublicKey publicKey) {
+    mclSize                    serializedPublicKeySize = 32;
+    std::vector<unsigned char> serialized_pubkey(serializedPublicKeySize * 2);
+    uint8_t*                   dst      = serialized_pubkey.data();
+    const blsPublicKey*        pub      = publicKey.getPtr();
+    const mcl::bn::G1*         g1Point  = reinterpret_cast<const mcl::bn::G1*>(&pub->v);
+    mcl::bn::G1                g1Point2 = *g1Point;
     g1Point2.normalize();
     if (g1Point2.x.serialize(dst, serializedPublicKeySize, mcl::IoSerialize | mcl::IoBigEndian) == 0)
         throw std::runtime_error("size of x is zero");
     if (g1Point2.y.serialize(dst + serializedPublicKeySize, serializedPublicKeySize, mcl::IoSerialize | mcl::IoBigEndian) == 0)
         throw std::runtime_error("size of y is zero");
-
     return utils::toHexString(serialized_pubkey);
+}
+
+bls::PublicKey utils::HexToBLSPublicKey(std::string_view hex) {
+    const size_t BLS_PKEY_COMPONENT_HEX_SIZE = 32 * 2;
+    const size_t BLS_PKEY_HEX_SIZE           = BLS_PKEY_COMPONENT_HEX_SIZE * 2;
+    hex                                      = utils::trimPrefix(hex, "0x");
+
+    if (hex.size() != BLS_PKEY_HEX_SIZE) {
+        std::stringstream stream;
+        stream << "Failed to deserialize BLS key hex '" << hex << "': A serialized BLS key is " << BLS_PKEY_HEX_SIZE << " hex characters, input hex was " << hex.size() << " characters";
+        throw std::runtime_error(stream.str());
+    }
+
+    // NOTE: Divide the 2 keys into the X,Y component
+    std::string_view              pkeyXHex = hex.substr(0,                           BLS_PKEY_COMPONENT_HEX_SIZE);
+    std::string_view              pkeyYHex = hex.substr(BLS_PKEY_COMPONENT_HEX_SIZE, BLS_PKEY_COMPONENT_HEX_SIZE);
+    std::array<unsigned char, 32> pkeyX    = utils::fromHexString32Byte(pkeyXHex);
+    std::array<unsigned char, 32> pkeyY    = utils::fromHexString32Byte(pkeyYHex);
+
+    // NOTE: In `PublicKeyToHex` before we serialize the G1 point, we normalize
+    // the point which divides X, Y by the Z component. This transformation then
+    // converts the divisor to 1 (Z) as the division has already been applied to
+    // X and Y. Here we reconstruct Z as 1.
+    std::array<unsigned char, 32> pkeyZ = {};
+    pkeyZ.data()[0]                     = 1;
+
+    // NOTE: This is the reverse of utils::PublicKeyToHex (above). We serialize
+    // a G1 point to conform the required format to interop directly with
+    // Solidity's BN256G1 library.
+    mcl::bn::G1 g1Point = {};
+    g1Point.clear(); // NOTE: Default init has *uninitialized values*!
+
+    // NOTE: Deserialize the components back into the point.
+    size_t readX = g1Point.x.deserialize(pkeyX.data(), pkeyX.size(), mcl::IoSerialize | mcl::IoBigEndian);
+    size_t readY = g1Point.y.deserialize(pkeyY.data(), pkeyY.size(), mcl::IoSerialize | mcl::IoBigEndian);
+    size_t readZ = g1Point.z.deserialize(pkeyZ.data(), pkeyZ.size(), mcl::IoSerialize);
+
+    // NOTE: This is hardcoded so it should always succeed, if not something
+    // bad has gone wrong.
+    assert(readZ == pkeyZ.size());
+
+    if (readX != pkeyX.size()) {
+        std::stringstream stream;
+        stream << "Failed to deserialize BLS key 'x' component '" << pkeyXHex << "', input hex was: '" << hex << "'";
+        throw std::runtime_error(stream.str());
+    }
+
+    if (readY != pkeyY.size()) {
+        std::stringstream stream;
+        stream << "Failed to deserialize BLS key 'y' component '" << pkeyYHex << "', input hex was: '" << hex << "'";
+        throw std::runtime_error(stream.str());
+    }
+
+    // TODO: It's impossible to create a bls::PublicKey from a G1 point through
+    // the C++ interface. It allows deserialization from a hex string, but, the
+    // hex string must originally have been serialised through its member
+    // function.
+    //
+    // Since we have a custom format for Solidity, although we can reconstruct
+    // the individual components of the public key in binary we have to go a
+    // roundabout way to restore these bytes into the key.
+    //
+    // const_cast away the pointer which is legal because the original object
+    // was not declared const.
+    bls::PublicKey result = {};
+    blsPublicKey*  rawKey = const_cast<blsPublicKey*>(result.getPtr());
+    std::memcpy(rawKey->v.x.d, g1Point.x.getUnit(), sizeof(rawKey->v.x.d));
+    std::memcpy(rawKey->v.y.d, g1Point.y.getUnit(), sizeof(rawKey->v.y.d));
+    std::memcpy(rawKey->v.z.d, g1Point.z.getUnit(), sizeof(rawKey->v.z.d));
+
+    return result;
 }
 
 std::array<unsigned char, 32> utils::HashModulus(std::string message) {

--- a/test/cpp/src/service_node_list.cpp
+++ b/test/cpp/src/service_node_list.cpp
@@ -28,7 +28,7 @@ std::string buildTag(const std::string& baseTag, uint32_t chainID, const std::st
     return utils::toHexString(utils::hash(concatenatedTag));
 }
 
-bls::Signature ServiceNode::signHash(const std::array<unsigned char, 32>& hash) {
+bls::Signature ServiceNode::signHash(const std::array<unsigned char, 32>& hash) const {
     bls::Signature sig;
     secretKey.signHash(sig, hash.data(), hash.size());
     return sig;
@@ -46,13 +46,13 @@ std::string ServiceNode::proofOfPossession(uint32_t chainID, const std::string& 
     return utils::SignatureToHex(sig);
 }
 
-std::string ServiceNode::getPublicKeyHex() {
+std::string ServiceNode::getPublicKeyHex() const {
     bls::PublicKey publicKey;
     secretKey.getPublicKey(publicKey);
-    return utils::PublicKeyToHex(publicKey);
+    return utils::BLSPublicKeyToHex(publicKey);
 }
 
-bls::PublicKey ServiceNode::getPublicKey() {
+bls::PublicKey ServiceNode::getPublicKey() const {
     bls::PublicKey publicKey;
     secretKey.getPublicKey(publicKey);
     return publicKey;
@@ -105,7 +105,7 @@ std::string ServiceNodeList::aggregatePubkeyHex() {
     for(auto& node : nodes) {
         aggregate_pubkey.add(node.getPublicKey());
     }
-    return utils::PublicKeyToHex(aggregate_pubkey);
+    return utils::BLSPublicKeyToHex(aggregate_pubkey);
 }
 
 std::string ServiceNodeList::aggregateSignatures(const std::string& message) {


### PR DESCRIPTION
This depends on https://github.com/oxen-io/ethyl/pull/11 being merged.

Added a way to invoke `serviceNodes()` and `serviceNodeIDs()` from the smart contract in C++ meaning we can test the service node data stored on the EVM. Included is various fixes and helper APIs to achieve that.

- Fixed UB with reinterpret_cast  when converting C++ BLS pkeys into serializable form using memcpy
- Add the reverse function to convert serialized BLS pkeys in hex back to a binary BLS public key
- Update ethyl with various support functionality

This is just the base functionality and a few supporting tests. More in depth tests can follow but I'd like to checkpoint the work into the mainline branch so everyone's on the same page.