### PR TITLE
Doubly-linked-list with sentinel change in smart contract

### DIFF
--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -23,9 +23,9 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     IERC20 public foundationPool;
 
     uint64 public constant LIST_SENTINEL                       = 0;
-    uint64 public nextServiceNodeID                            = LIST_SENTINEL + 1;
     uint256 public constant MAX_SERVICE_NODE_REMOVAL_WAIT_TIME = 30 days;
 
+    uint64  public nextServiceNodeID;
     uint256 public totalNodes;
     uint256 public blsNonSignerThreshold;
     uint256 public upperLimitNonSigners;
@@ -49,22 +49,23 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     /// @param recipientRatio_ The recipient ratio for rewards
     function initialize(address token_, address foundationPool_, uint256 stakingRequirement_, uint256 liquidatorRewardRatio_, uint256 poolShareOfLiquidationRatio_, uint256 recipientRatio_) initializer()  public {
         if (recipientRatio_ < 1) revert RecipientRewardsTooLow();
-        IsActive = false;
-        nextServiceNodeID = 1;
-        totalNodes = 0;
-        blsNonSignerThreshold = 0;
-        upperLimitNonSigners = 300;
-        proofOfPossessionTag = buildTag("BLS_SIG_TRYANDINCREMENT_POP");
-        rewardTag = buildTag("BLS_SIG_TRYANDINCREMENT_REWARD");
-        removalTag = buildTag("BLS_SIG_TRYANDINCREMENT_REMOVE");
-        liquidateTag = buildTag("BLS_SIG_TRYANDINCREMENT_LIQUIDATE");
+        IsActive                     = false;
+        nextServiceNodeID            = 1;
+        totalNodes                   = 0;
+        blsNonSignerThreshold        = 0;
+        upperLimitNonSigners         = 300;
+        proofOfPossessionTag         = buildTag("BLS_SIG_TRYANDINCREMENT_POP");
+        rewardTag                    = buildTag("BLS_SIG_TRYANDINCREMENT_REWARD");
+        removalTag                   = buildTag("BLS_SIG_TRYANDINCREMENT_REMOVE");
+        liquidateTag                 = buildTag("BLS_SIG_TRYANDINCREMENT_LIQUIDATE");
 
-        designatedToken = IERC20(token_);
-        foundationPool = IERC20(foundationPool_);
-        _stakingRequirement = stakingRequirement_;
-        _liquidatorRewardRatio = liquidatorRewardRatio_;
+        designatedToken              = IERC20(token_);
+        foundationPool               = IERC20(foundationPool_);
+        _stakingRequirement          = stakingRequirement_;
+        _liquidatorRewardRatio       = liquidatorRewardRatio_;
         _poolShareOfLiquidationRatio = poolShareOfLiquidationRatio_;
-        _recipientRatio = recipientRatio_;
+        _recipientRatio              = recipientRatio_;
+        nextServiceNodeID            = LIST_SENTINEL + 1;
 
         // Doubly-linked list with sentinel that points to itself.
         //

--- a/contracts/ServiceNodeRewards.sol
+++ b/contracts/ServiceNodeRewards.sol
@@ -22,8 +22,8 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     IERC20 public designatedToken;
     IERC20 public foundationPool;
 
-    uint64 public nextServiceNodeID;
-    uint64 public constant LIST_END = type(uint64).max;
+    uint64 public constant LIST_SENTINEL                       = 0;
+    uint64 public nextServiceNodeID                            = LIST_SENTINEL + 1;
     uint256 public constant MAX_SERVICE_NODE_REMOVAL_WAIT_TIME = 30 days;
 
     uint256 public totalNodes;
@@ -66,10 +66,15 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
         _poolShareOfLiquidationRatio = poolShareOfLiquidationRatio_;
         _recipientRatio = recipientRatio_;
 
-        _serviceNodes[LIST_END].previous = LIST_END;
-        _serviceNodes[LIST_END].next = LIST_END;
-        __Ownable_init(msg.sender);
+        // Doubly-linked list with sentinel that points to itself.
+        //
+        // +-<prev- [Sentinel] -next->-+
+        // |                           |
+        // +----------------------------
 
+        _serviceNodes[LIST_SENTINEL].prev = LIST_SENTINEL;
+        _serviceNodes[LIST_SENTINEL].next = LIST_SENTINEL;
+        __Ownable_init(msg.sender);
     }
 
     mapping(uint64 => ServiceNode) private _serviceNodes;
@@ -203,31 +208,16 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
             contributors[0] = Contributor(operator, _stakingRequirement);
         }
         uint64 serviceNodeID = serviceNodeIDs[BN256G1.getKeyForG1Point(blsPubkey)];
-        if(serviceNodeID != 0) revert BLSPubkeyAlreadyExists(serviceNodeID);
+        if (serviceNodeID != 0) revert BLSPubkeyAlreadyExists(serviceNodeID);
         validateProofOfPossession(blsPubkey, blsSignature, operator, serviceNodeParams.serviceNodePubkey);
-        uint64 previous = _serviceNodes[LIST_END].previous;
 
-        /*_serviceNodes[nextServiceNodeID] = ServiceNode(previous, operator, pubkey, LIST_END);*/
-        _serviceNodes[previous].next = nextServiceNodeID;
-        _serviceNodes[nextServiceNodeID].previous = previous;
-        _serviceNodes[nextServiceNodeID].next = LIST_END;
-        _serviceNodes[nextServiceNodeID].pubkey = blsPubkey;
+        uint64 allocID                  = serviceNodeAdd(blsPubkey);
         // TODO sean only operator can exit atm need to make any contributor
-        _serviceNodes[nextServiceNodeID].operator = operator;
-        _serviceNodes[nextServiceNodeID].deposit = _stakingRequirement;
-        _serviceNodes[LIST_END].previous = nextServiceNodeID;
+        _serviceNodes[allocID].operator = operator;
+        _serviceNodes[allocID].deposit  = _stakingRequirement;
 
-        serviceNodeIDs[BN256G1.getKeyForG1Point(blsPubkey)] = nextServiceNodeID;
-
-        if (_serviceNodes[LIST_END].next != LIST_END) {
-            _aggregatePubkey = BN256G1.add(_aggregatePubkey, blsPubkey);
-        } else {
-            _aggregatePubkey = blsPubkey;
-        }
-        totalNodes++;
         updateBLSThreshold();
-        emit NewServiceNode(nextServiceNodeID, operator, blsPubkey, serviceNodeParams, contributors);
-        nextServiceNodeID++;
+        emit NewServiceNode(allocID, operator, blsPubkey, serviceNodeParams, contributors);
         SafeERC20.safeTransferFrom(designatedToken, operator, address(this), _stakingRequirement);
     }
 
@@ -297,26 +287,12 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     /// @dev Internal function to remove a BLS public key. Updates the linked list to remove the node
     /// @param serviceNodeID The ID of the service node to be removed.
     function _removeBLSPublicKey(uint64 serviceNodeID, uint256 returnedAmount) internal {
-        address serviceNodeOperator = _serviceNodes[serviceNodeID].operator;
-        uint64 previousServiceNode = _serviceNodes[serviceNodeID].previous;
-        uint64 nextServiceNode = _serviceNodes[serviceNodeID].next;
-        if (nextServiceNode == 0) revert ServiceNodeDoesntExist(serviceNodeID);
+        address         operator      = _serviceNodes[serviceNodeID].operator;
+        BN256G1.G1Point memory pubkey = _serviceNodes[serviceNodeID].pubkey;
+        serviceNodeDelete(serviceNodeID);
 
-        _serviceNodes[previousServiceNode].next = nextServiceNode;
-        _serviceNodes[nextServiceNode].previous = previousServiceNode;
-
-        BN256G1.G1Point memory pubkey = BN256G1.G1Point(_serviceNodes[serviceNodeID].pubkey.X, _serviceNodes[serviceNodeID].pubkey.Y);
-
-        _aggregatePubkey = BN256G1.add(_aggregatePubkey, BN256G1.negate(pubkey));
-
-        delete _serviceNodes[serviceNodeID];
-
-        delete serviceNodeIDs[BN256G1.getKeyForG1Point(pubkey)];
-
-        totalNodes--;
         updateBLSThreshold();
-
-        emit ServiceNodeRemoval(serviceNodeID, serviceNodeOperator, returnedAmount, pubkey);
+        emit ServiceNodeRemoval(serviceNodeID, operator, returnedAmount, pubkey);
     }
 
     /// @notice Removes a BLS public key using a bls signature and rewards the caller for doing so. This function can be called by anyone, but requires the network to provide a valid signature to do so. The nodes will only provides this signature if the network wishes for the node to be forcably removed (ie from a dereg) without relying on the user to remove themselves.
@@ -366,38 +342,12 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     /// @param amounts Array of amounts that the service node has staked, associated with each public key.
     function seedPublicKeyList(uint256[] calldata pkX, uint256[] calldata pkY, uint256[] calldata amounts) external onlyOwner {
         if (pkX.length != pkY.length || pkX.length != amounts.length) revert ArrayLengthMismatch();
-        uint64 lastServiceNodeID = _serviceNodes[LIST_END].previous;
-        bool firstServiceNode = serviceNodesLength() == 0;
-
-        for(uint256 i = 0; i < pkX.length; i++) {
-            BN256G1.G1Point memory pubkey = BN256G1.G1Point(pkX[i], pkY[i]);
-            bytes memory pubkeybytes = BN256G1.getKeyForG1Point(pubkey);
-            uint64 serviceNodeID = serviceNodeIDs[pubkeybytes];
-            if(serviceNodeID != 0) revert BLSPubkeyAlreadyExists(serviceNodeID);
-
-            /*_serviceNodes[nextServiceNodeID] = ServiceNode(previous, recipient, pubkey, LIST_END);*/
-            _serviceNodes[lastServiceNodeID].next = nextServiceNodeID;
-            _serviceNodes[nextServiceNodeID].previous = lastServiceNodeID;
-            _serviceNodes[nextServiceNodeID].pubkey = pubkey;
-            _serviceNodes[nextServiceNodeID].deposit = amounts[i];
-
-            serviceNodeIDs[pubkeybytes] = nextServiceNodeID;
-
-            if (!firstServiceNode) {
-                _aggregatePubkey = BN256G1.add(_aggregatePubkey, pubkey);
-            } else {
-                _aggregatePubkey = pubkey;
-                firstServiceNode = false;
-            }
-
-            emit NewSeededServiceNode(nextServiceNodeID, pubkey);
-            lastServiceNodeID = nextServiceNodeID;
-            nextServiceNodeID++;
-            totalNodes++;
+        for (uint256 i = 0; i < pkX.length; i++) {
+            BN256G1.G1Point memory pubkey  = BN256G1.G1Point(pkX[i], pkY[i]);
+            uint64 allocID                 = serviceNodeAdd(pubkey);
+            _serviceNodes[allocID].deposit = amounts[i];
+            emit NewSeededServiceNode(allocID, pubkey);
         }
-
-        _serviceNodes[lastServiceNodeID].next = LIST_END;
-        _serviceNodes[LIST_END].previous = lastServiceNodeID;
 
         updateBLSThreshold();
     }
@@ -463,10 +413,10 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     /// @notice Counts the number of service nodes in the linked list.
     /// @return count The total number of service nodes in the list.
     function serviceNodesLength() public view returns (uint256 count) {
-        uint64 currentNode = _serviceNodes[LIST_END].next;
+        uint64 currentNode = _serviceNodes[LIST_SENTINEL].next;
         count = 0;
 
-        while (currentNode != LIST_END) {
+        while (currentNode != LIST_SENTINEL) {
             count++;
             currentNode = _serviceNodes[currentNode].next;
         }
@@ -512,6 +462,75 @@ contract ServiceNodeRewards is Initializable, Ownable2StepUpgradeable, PausableU
     function buildTag(string memory baseTag) private view returns (bytes32) {
         return keccak256(bytes(abi.encodePacked(baseTag, block.chainid, address(this))));
     }
+
+    /// @notice Add the service node with the specified BLS public key to
+    /// the service node list. EVM revert if the service node already exists.
+    /// @return result The ID allocated for the service node. The service node can then
+    /// be accessed by `_serviceNodes[result]`
+    function serviceNodeAdd(BN256G1.G1Point memory pubkey) internal returns (uint64 result) {
+        // NOTE: Check if the service node already exists
+        // (e.g. <BLS Key> -> <SN> mapping)
+        bytes memory pubkeyBytes = BN256G1.getKeyForG1Point(pubkey);
+        if (serviceNodeIDs[pubkeyBytes] != LIST_SENTINEL)
+            revert BLSPubkeyAlreadyExists(serviceNodeIDs[pubkeyBytes]);
+
+        result             = nextServiceNodeID;
+        nextServiceNodeID += 1;
+        totalNodes        += 1;
+
+        // NOTE: Create service node slot and patch up the slot links.
+        //
+        // The following is the insertion pattern in a doubly-linked list
+        // with sentinel at index 0
+        //
+        // ```c
+        // node->next       = sentinel;
+        // node->prev       = sentinel->prev;
+        // node->next->prev = node;
+        // node->prev->next = node;
+        // ```
+        _serviceNodes[result].next                     = LIST_SENTINEL;
+        _serviceNodes[result].prev                     = _serviceNodes[LIST_SENTINEL].prev;
+        _serviceNodes[_serviceNodes[result].next].prev = result;
+        _serviceNodes[_serviceNodes[result].prev].next = result;
+
+        // NOTE: Assign BLS pubkey
+        _serviceNodes[result].pubkey                   = pubkey;
+
+        // NOTE: Create mapping from <BLS Key> -> <SN Linked List Index>
+        serviceNodeIDs[pubkeyBytes] = result;
+
+        if (totalNodes == 1) {
+            _aggregatePubkey = pubkey;
+        } else {
+            _aggregatePubkey = BN256G1.add(_aggregatePubkey, pubkey);
+        }
+        return result;
+    }
+
+    /// @notice Delete the service node with `nodeID`
+    /// @param nodeID The ID of the service node to delete
+    function serviceNodeDelete(uint64 nodeID) internal {
+        ServiceNode memory node = _serviceNodes[nodeID];
+
+        // The following is the deletion pattern in a doubly-linked list
+        // with sentinel at index 0
+        //
+        // ```c
+        // node->next->prev = node->prev;
+        // node->prev->next = node->next;
+        // ```
+        _serviceNodes[node.next].prev = node.prev;
+        _serviceNodes[node.prev].next = node.next;
+
+        // NOTE: Update aggregate BLS key
+        _aggregatePubkey = BN256G1.add(_aggregatePubkey, BN256G1.negate(node.pubkey));
+
+        // NOTE: Delete service node from EVM storage
+        bytes memory pubkeyBytes = BN256G1.getKeyForG1Point(node.pubkey);
+        delete _serviceNodes[nodeID];
+        delete serviceNodeIDs[pubkeyBytes]; // Delete mapping
+
+        totalNodes -= 1;
+    }
 }
-
-

--- a/contracts/interfaces/IServiceNodeRewards.sol
+++ b/contracts/interfaces/IServiceNodeRewards.sol
@@ -8,7 +8,7 @@ interface IServiceNodeRewards {
     /// @notice Represents a service node in the network.
     struct ServiceNode {
         uint64 next;
-        uint64 previous;
+        uint64 prev;
         address operator;
         BN256G1.G1Point pubkey;
         uint256 leaveRequestTimestamp;

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -57,8 +57,6 @@ include(cmake/SourcesAndHeaders.cmake)
 FetchContent_Declare(nlohmann URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
 FetchContent_MakeAvailable(nlohmann)
 
-find_package(Boost 1.62 QUIET REQUIRED COMPONENTS system thread serialization program_options)
-
 add_subdirectory(external)
 
 add_library(

--- a/test/cpp/include/service_node_rewards/ec_utils.hpp
+++ b/test/cpp/include/service_node_rewards/ec_utils.hpp
@@ -16,7 +16,7 @@
 
 namespace utils
 {
-    std::string                   BLSPublicKeyToHex(bls::PublicKey publicKey);
+    std::string                   BLSPublicKeyToHex(const bls::PublicKey& publicKey);
     bls::PublicKey                HexToBLSPublicKey(std::string_view hex);
     std::string                   SignatureToHex(bls::Signature sig);
     std::array<unsigned char, 32> HashModulus(std::string message);

--- a/test/cpp/include/service_node_rewards/ec_utils.hpp
+++ b/test/cpp/include/service_node_rewards/ec_utils.hpp
@@ -16,10 +16,8 @@
 
 namespace utils
 {
-
-    std::string PublicKeyToHex(bls::PublicKey publicKey);
-    std::string SignatureToHex(bls::Signature sig);
+    std::string                   BLSPublicKeyToHex(bls::PublicKey publicKey);
+    bls::PublicKey                HexToBLSPublicKey(std::string_view hex);
+    std::string                   SignatureToHex(bls::Signature sig);
     std::array<unsigned char, 32> HashModulus(std::string message);
-
-// END
 }

--- a/test/cpp/include/service_node_rewards/service_node_list.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_list.hpp
@@ -24,11 +24,10 @@ public:
     uint64_t service_node_id;
     ServiceNode(uint64_t _service_node_id);
     ~ServiceNode();
-    bls::Signature signHash(const std::array<unsigned char, 32>& hash);
-    std::string proofOfPossession(uint32_t chainID, const std::string& contractAddress, const std::string& senderEthAddress, const std::string& serviceNodePubkey);
-    std::string getPublicKeyHex();
-    bls::PublicKey getPublicKey();
-// End Service Node
+    bls::Signature signHash(const std::array<unsigned char, 32>& hash) const;
+    std::string    proofOfPossession(uint32_t chainID, const std::string& contractAddress, const std::string& senderEthAddress, const std::string& serviceNodePubkey);
+    std::string    getPublicKeyHex() const;
+    bls::PublicKey getPublicKey() const;
 };
 
 class ServiceNodeList {

--- a/test/cpp/include/service_node_rewards/service_node_list.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_list.hpp
@@ -17,13 +17,15 @@
 #include <string>
 #include <vector>
 
+constexpr inline uint64_t SERVICE_NODE_LIST_SENTINEL = 0;
+
 class ServiceNode {
 private:
     bls::SecretKey secretKey;
 public:
-    uint64_t service_node_id;
+    uint64_t service_node_id = SERVICE_NODE_LIST_SENTINEL;
+    ServiceNode() = default;
     ServiceNode(uint64_t _service_node_id);
-    ~ServiceNode();
     bls::Signature signHash(const std::array<unsigned char, 32>& hash) const;
     std::string    proofOfPossession(uint32_t chainID, const std::string& contractAddress, const std::string& senderEthAddress, const std::string& serviceNodePubkey);
     std::string    getPublicKeyHex() const;
@@ -32,8 +34,8 @@ public:
 
 class ServiceNodeList {
 public:
-    uint64_t next_service_node_id = 1;
     std::vector<ServiceNode> nodes;
+    uint64_t                 next_service_node_id = SERVICE_NODE_LIST_SENTINEL + 1;
 
     ServiceNodeList(size_t numNodes);
     ~ServiceNodeList();

--- a/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <string_view>
 #include <vector>
 #include <memory>
 
@@ -15,18 +16,32 @@ struct Recipient {
     Recipient(uint64_t _rewards, uint64_t _claimed) : rewards(_rewards), claimed(_claimed) {}
 };
 
+struct ContractServiceNode {
+    uint64_t                      next;
+    uint64_t                      prev;
+    std::array<unsigned char, 20> recipient;
+    bls::PublicKey                pubkey;
+    uint64_t                      leaveRequestTimestamp;
+    std::string                   deposit;
+};
+
 class ServiceNodeRewardsContract {
 public:
+    // TODO: Taken from scripts/deploy-local-test.js and hardcoded
+    static constexpr inline uint64_t STAKING_REQUIREMENT = 15'000'000'000'000;
+
     // Constructor
     ServiceNodeRewardsContract(const std::string& _contractAddress, std::shared_ptr<Provider> _provider);
 
     // Method for creating a transaction to add a public key
     Transaction addBLSPublicKey(const std::string& publicKey, const std::string& sig, const std::string& serviceNodePubkey, const std::string& serviceNodeSignature, uint64_t fee);
 
-    uint64_t serviceNodesLength();
-    std::string designatedToken();
-    std::string aggregatePubkey();
-    Recipient viewRecipientData(const std::string& address);
+    ContractServiceNode serviceNodes(uint64_t index);
+    uint64_t            serviceNodeIDs(const bls::PublicKey& pKey);
+    uint64_t            serviceNodesLength();
+    std::string         designatedToken();
+    std::string         aggregatePubkey();
+    Recipient           viewRecipientData(const std::string& address);
 
     Transaction liquidateBLSPublicKeyWithSignature(const uint64_t service_node_id, const std::string& pubkey, const std::string& sig, const std::vector<uint64_t>& non_signer_indices);
     Transaction initiateRemoveBLSPublicKey(const uint64_t service_node_id);

--- a/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
@@ -28,7 +28,7 @@ struct ContractServiceNode {
 class ServiceNodeRewardsContract {
 public:
     // TODO: Taken from scripts/deploy-local-test.js and hardcoded
-    static constexpr inline uint64_t STAKING_REQUIREMENT = 15'000'000'000'000;
+    static constexpr inline uint64_t STAKING_REQUIREMENT = 100'000'000'000;
 
     // Constructor
     ServiceNodeRewardsContract(const std::string& _contractAddress, std::shared_ptr<Provider> _provider);

--- a/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
+++ b/test/cpp/include/service_node_rewards/service_node_rewards_contract.hpp
@@ -40,7 +40,8 @@ public:
     uint64_t            serviceNodeIDs(const bls::PublicKey& pKey);
     uint64_t            serviceNodesLength();
     std::string         designatedToken();
-    std::string         aggregatePubkey();
+    std::string         aggregatePubkeyString();
+    bls::PublicKey      aggregatePubkey();
     Recipient           viewRecipientData(const std::string& address);
 
     Transaction liquidateBLSPublicKeyWithSignature(const uint64_t service_node_id, const std::string& pubkey, const std::string& sig, const std::vector<uint64_t>& non_signer_indices);

--- a/test/cpp/src/ec_utils.cpp
+++ b/test/cpp/src/ec_utils.cpp
@@ -1,6 +1,8 @@
 #include "service_node_rewards/ec_utils.hpp"
 #include "ethyl/utils.hpp"
 
+#include <cstring>
+
 std::string utils::SignatureToHex(bls::Signature sig) {
     mclSize serializedSignatureSize = 32;
     std::vector<unsigned char> serialized_signature(serializedSignatureSize*4);
@@ -20,20 +22,90 @@ std::string utils::SignatureToHex(bls::Signature sig) {
     return utils::toHexString(serialized_signature);
 }
 
-std::string utils::PublicKeyToHex(bls::PublicKey publicKey) {
-    mclSize serializedPublicKeySize = 32;
-    std::vector<unsigned char> serialized_pubkey(serializedPublicKeySize*2);
-    uint8_t *dst = serialized_pubkey.data();
-    const blsPublicKey* pub = publicKey.getPtr();  
-    const mcl::bn::G1* g1Point = reinterpret_cast<const mcl::bn::G1*>(&pub->v);
-    mcl::bn::G1 g1Point2 = *g1Point;
+std::string utils::BLSPublicKeyToHex(bls::PublicKey publicKey) {
+    mclSize                    serializedPublicKeySize = 32;
+    std::vector<unsigned char> serialized_pubkey(serializedPublicKeySize * 2);
+    uint8_t*                   dst      = serialized_pubkey.data();
+    const blsPublicKey*        pub      = publicKey.getPtr();
+    const mcl::bn::G1*         g1Point  = reinterpret_cast<const mcl::bn::G1*>(&pub->v);
+    mcl::bn::G1                g1Point2 = *g1Point;
     g1Point2.normalize();
     if (g1Point2.x.serialize(dst, serializedPublicKeySize, mcl::IoSerialize | mcl::IoBigEndian) == 0)
         throw std::runtime_error("size of x is zero");
     if (g1Point2.y.serialize(dst + serializedPublicKeySize, serializedPublicKeySize, mcl::IoSerialize | mcl::IoBigEndian) == 0)
         throw std::runtime_error("size of y is zero");
-
     return utils::toHexString(serialized_pubkey);
+}
+
+bls::PublicKey utils::HexToBLSPublicKey(std::string_view hex) {
+    const size_t BLS_PKEY_COMPONENT_HEX_SIZE = 32 * 2;
+    const size_t BLS_PKEY_HEX_SIZE           = BLS_PKEY_COMPONENT_HEX_SIZE * 2;
+    hex                                      = utils::trimPrefix(hex, "0x");
+
+    if (hex.size() != BLS_PKEY_HEX_SIZE) {
+        std::stringstream stream;
+        stream << "Failed to deserialize BLS key hex '" << hex << "': A serialized BLS key is " << BLS_PKEY_HEX_SIZE << " hex characters, input hex was " << hex.size() << " characters";
+        throw std::runtime_error(stream.str());
+    }
+
+    // NOTE: Divide the 2 keys into the X,Y component
+    std::string_view              pkeyXHex = hex.substr(0,                           BLS_PKEY_COMPONENT_HEX_SIZE);
+    std::string_view              pkeyYHex = hex.substr(BLS_PKEY_COMPONENT_HEX_SIZE, BLS_PKEY_COMPONENT_HEX_SIZE);
+    std::array<unsigned char, 32> pkeyX    = utils::fromHexString32Byte(pkeyXHex);
+    std::array<unsigned char, 32> pkeyY    = utils::fromHexString32Byte(pkeyYHex);
+
+    // NOTE: In `PublicKeyToHex` before we serialize the G1 point, we normalize
+    // the point which divides X, Y by the Z component. This transformation then
+    // converts the divisor to 1 (Z) as the division has already been applied to
+    // X and Y. Here we reconstruct Z as 1.
+    std::array<unsigned char, 32> pkeyZ = {};
+    pkeyZ.data()[0]                     = 1;
+
+    // NOTE: This is the reverse of utils::PublicKeyToHex (above). We serialize
+    // a G1 point to conform the required format to interop directly with
+    // Solidity's BN256G1 library.
+    mcl::bn::G1 g1Point = {};
+    g1Point.clear(); // NOTE: Default init has *uninitialized values*!
+
+    // NOTE: Deserialize the components back into the point.
+    size_t readX = g1Point.x.deserialize(pkeyX.data(), pkeyX.size(), mcl::IoSerialize | mcl::IoBigEndian);
+    size_t readY = g1Point.y.deserialize(pkeyY.data(), pkeyY.size(), mcl::IoSerialize | mcl::IoBigEndian);
+    size_t readZ = g1Point.z.deserialize(pkeyZ.data(), pkeyZ.size(), mcl::IoSerialize);
+
+    // NOTE: This is hardcoded so it should always succeed, if not something
+    // bad has gone wrong.
+    assert(readZ == pkeyZ.size());
+
+    if (readX != pkeyX.size()) {
+        std::stringstream stream;
+        stream << "Failed to deserialize BLS key 'x' component '" << pkeyXHex << "', input hex was: '" << hex << "'";
+        throw std::runtime_error(stream.str());
+    }
+
+    if (readY != pkeyY.size()) {
+        std::stringstream stream;
+        stream << "Failed to deserialize BLS key 'y' component '" << pkeyYHex << "', input hex was: '" << hex << "'";
+        throw std::runtime_error(stream.str());
+    }
+
+    // TODO: It's impossible to create a bls::PublicKey from a G1 point through
+    // the C++ interface. It allows deserialization from a hex string, but, the
+    // hex string must originally have been serialised through its member
+    // function.
+    //
+    // Since we have a custom format for Solidity, although we can reconstruct
+    // the individual components of the public key in binary we have to go a
+    // roundabout way to restore these bytes into the key.
+    //
+    // const_cast away the pointer which is legal because the original object
+    // was not declared const.
+    bls::PublicKey result = {};
+    blsPublicKey*  rawKey = const_cast<blsPublicKey*>(result.getPtr());
+    std::memcpy(rawKey->v.x.d, g1Point.x.getUnit(), sizeof(rawKey->v.x.d));
+    std::memcpy(rawKey->v.y.d, g1Point.y.getUnit(), sizeof(rawKey->v.y.d));
+    std::memcpy(rawKey->v.z.d, g1Point.z.getUnit(), sizeof(rawKey->v.z.d));
+
+    return result;
 }
 
 std::array<unsigned char, 32> utils::HashModulus(std::string message) {

--- a/test/cpp/src/service_node_list.cpp
+++ b/test/cpp/src/service_node_list.cpp
@@ -28,7 +28,7 @@ std::string buildTag(const std::string& baseTag, uint32_t chainID, const std::st
     return utils::toHexString(utils::hash(concatenatedTag));
 }
 
-bls::Signature ServiceNode::signHash(const std::array<unsigned char, 32>& hash) {
+bls::Signature ServiceNode::signHash(const std::array<unsigned char, 32>& hash) const {
     bls::Signature sig;
     secretKey.signHash(sig, hash.data(), hash.size());
     return sig;
@@ -46,13 +46,13 @@ std::string ServiceNode::proofOfPossession(uint32_t chainID, const std::string& 
     return utils::SignatureToHex(sig);
 }
 
-std::string ServiceNode::getPublicKeyHex() {
+std::string ServiceNode::getPublicKeyHex() const {
     bls::PublicKey publicKey;
     secretKey.getPublicKey(publicKey);
-    return utils::PublicKeyToHex(publicKey);
+    return utils::BLSPublicKeyToHex(publicKey);
 }
 
-bls::PublicKey ServiceNode::getPublicKey() {
+bls::PublicKey ServiceNode::getPublicKey() const {
     bls::PublicKey publicKey;
     secretKey.getPublicKey(publicKey);
     return publicKey;
@@ -105,7 +105,7 @@ std::string ServiceNodeList::aggregatePubkeyHex() {
     for(auto& node : nodes) {
         aggregate_pubkey.add(node.getPublicKey());
     }
-    return utils::PublicKeyToHex(aggregate_pubkey);
+    return utils::BLSPublicKeyToHex(aggregate_pubkey);
 }
 
 std::string ServiceNodeList::aggregateSignatures(const std::string& message) {

--- a/test/cpp/src/service_node_list.cpp
+++ b/test/cpp/src/service_node_list.cpp
@@ -16,9 +16,6 @@ ServiceNode::ServiceNode(uint64_t _service_node_id) {
     secretKey.init();
 }
 
-ServiceNode::~ServiceNode() {
-}
-
 std::string buildTag(const std::string& baseTag, uint32_t chainID, const std::string& contractAddress) {
     // Check if contractAddress starts with "0x" prefix
     std::string contractAddressOutput = contractAddress;

--- a/test/cpp/src/service_node_rewards_contract.cpp
+++ b/test/cpp/src/service_node_rewards_contract.cpp
@@ -53,7 +53,8 @@ ContractServiceNode ServiceNodeRewardsContract::serviceNodes(uint64_t index)
     result.prev                = utils::fromHexStringToUint64(prevHex);
 
     // NOTE: Deserialise recipient
-    std::vector<unsigned char> recipientBytes = utils::fromHexString(utils::trimLeadingZeros(recipientHex));
+    const size_t ETH_ADDRESS_HEX_SIZE = 20 * 2;
+    std::vector<unsigned char> recipientBytes = utils::fromHexString(recipientHex.substr(recipientHex.size() - ETH_ADDRESS_HEX_SIZE, ETH_ADDRESS_HEX_SIZE));
     assert(recipientBytes.size() == result.recipient.max_size());
     std::memcpy(result.recipient.data(), recipientBytes.data(), recipientBytes.size());
 
@@ -107,11 +108,17 @@ std::string ServiceNodeRewardsContract::designatedToken() {
     return provider->callReadFunction(callData);
 }
 
-std::string ServiceNodeRewardsContract::aggregatePubkey() {
-    ReadCallData callData;
+std::string ServiceNodeRewardsContract::aggregatePubkeyString() {
+    ReadCallData callData    = {};
     callData.contractAddress = contractAddress;
-    callData.data = utils::getFunctionSignature("aggregatePubkey()");
+    callData.data            = utils::getFunctionSignature("aggregatePubkey()");
     return provider->callReadFunction(callData);
+}
+
+bls::PublicKey ServiceNodeRewardsContract::aggregatePubkey() {
+    std::string    hex    = ServiceNodeRewardsContract::aggregatePubkeyString();
+    bls::PublicKey result = utils::HexToBLSPublicKey(hex);
+    return result;
 }
 
 Recipient ServiceNodeRewardsContract::viewRecipientData(const std::string& address) {

--- a/test/cpp/test/src/rewards_contract.cpp
+++ b/test/cpp/test/src/rewards_contract.cpp
@@ -27,6 +27,76 @@ std::string erc20_address = utils::trimAddress(rewards_contract.designatedToken(
 ERC20Contract erc20_contract(erc20_address, provider);
 std::string snapshot_id = provider->evm_snapshot();
 
+static void resetContractToSnapshot()
+{
+    REQUIRE(provider->evm_revert(snapshot_id));
+}
+
+// Given the service node list and the state of the list derived in C++, verify
+// that the smart contract's service node list matches what we expect it to be.
+static void verifyEVMServiceNodesAgainstCPPState(const ServiceNodeList& snl)
+{
+    // NOTE: Collect SNs from smart contract
+    std::vector<ContractServiceNode>                  snInContract;
+    std::unordered_map<uint64_t, ContractServiceNode> snInContractMap;
+    {
+        snInContract.reserve(1 /*sentinel*/ + snl.nodes.size());
+        snInContract.push_back(rewards_contract.serviceNodes(0)); // Collect sentinel
+
+        for (size_t index = 0; index < snl.nodes.size(); index++) {
+            auto&    cppNode = snl.nodes[index];
+            uint64_t snID    = rewards_contract.serviceNodeIDs(cppNode.getPublicKey());
+            snInContract.push_back(rewards_contract.serviceNodes(snID));
+            snInContractMap[snID] = snInContract.back();
+        }
+    }
+
+    const ServiceNode sentinelCppNode = {};
+    REQUIRE(1 /*sentinel*/ + snl.nodes.size() == snInContract.size());
+
+    std::string const STAKING_REQUIREMENT_HEX = utils::padTo32Bytes(utils::decimalToHex(ServiceNodeRewardsContract::STAKING_REQUIREMENT));
+
+    for (size_t index = 0; index < snl.nodes.size(); index++) {
+        const ServiceNode&         cppNode = snl.nodes[index];
+        const ContractServiceNode& ethNode = snInContractMap[cppNode.service_node_id];
+
+        // NOTE: Verify the ethereum address is correct
+        {
+            std::array<unsigned char, 20> walletPKeyHex = signer.secretKeyToAddress(seckey);
+            REQUIRE(ethNode.recipient == walletPKeyHex);
+        }
+
+        // NOTE: Verify metadata
+        REQUIRE(ethNode.leaveRequestTimestamp == 0);
+
+        // NOTE: Verify BLS key on the contract matches the C++ key
+        REQUIRE(ethNode.pubkey == cppNode.getPublicKey());
+
+        // NOTE: Verify the linked-list of service nodes. The SNL on the C++
+        // side is the order of the linked list because we manually mirror the
+        // operations to the C++ side.
+        {
+            // NOTE: Grab the next/prev nodes as determined by the C++ code
+            const ServiceNode& nextCppNode = (index + 1 < snl.nodes.size()) ? snl.nodes[index + 1] : sentinelCppNode;
+            const ServiceNode& prevCppNode = (index > 0)                    ? snl.nodes[index - 1] : sentinelCppNode;
+
+            INFO("Service node at index " << index << " had linked list links that did not match the expected values\n"
+                 << "  next: " << ethNode.next << " (expected: " << nextCppNode.service_node_id << ")\n"
+                 << "  prev: " << ethNode.prev << " (expected: " << prevCppNode.service_node_id << ")");
+            REQUIRE(ethNode.next == nextCppNode.service_node_id);
+            REQUIRE(ethNode.prev == prevCppNode.service_node_id);
+        }
+
+        // NOTE: Verify the staking requirement
+        {
+            INFO("Staking requirement did not match, ours was '" << STAKING_REQUIREMENT_HEX
+                 << "'. The contract reported '" << ethNode.deposit
+                 << "': Check if scripts/deploy-local-testnet.js requirement matches the hardcoded staking amount at ServiceNodeRewardsContract::STAKING_REQUIREMENT.");
+            REQUIRE(ethNode.deposit == STAKING_REQUIREMENT_HEX);
+        }
+    }
+}
+
 TEST_CASE( "Rewards Contract", "[ethereum]" ) {
     bool success_resetting_to_snapshot = provider->evm_revert(snapshot_id);
     snapshot_id = provider->evm_snapshot();
@@ -50,6 +120,7 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
 
     SECTION( "Add a public key to the smart contract" ) {
         REQUIRE(rewards_contract.serviceNodesLength() == 0);
+
         ServiceNodeList snl(1);
         for(auto& node : snl.nodes) {
             const auto pubkey              = node.getPublicKeyHex();
@@ -61,30 +132,8 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         }
         REQUIRE(rewards_contract.serviceNodesLength() == 1);
 
-        // NOTE: Verify the service node stored on the EVM
-        const ServiceNode& sn01    = snl.nodes[0];
-        uint64_t           snIndex = rewards_contract.serviceNodeIDs(sn01.getPublicKey());
-        REQUIRE(snIndex == 1); // First service node should be allocated index 1
-
-        ContractServiceNode sn01InContract = rewards_contract.serviceNodes(snIndex);
-        REQUIRE(sn01InContract.next == std::numeric_limits<uint64_t>::max());
-        REQUIRE(sn01InContract.prev == std::numeric_limits<uint64_t>::max());
-
-        // NOTE: Verify the ethereum address is correct
-        std::array<unsigned char, 20> walletPKeyHex = signer.secretKeyToAddress(seckey);
-        REQUIRE(sn01InContract.recipient             == walletPKeyHex);
-
-        // NOTE: Verify the BLS key
-        REQUIRE(sn01InContract.pubkey                == sn01.getPublicKey());
-
-        // NOTE: Verify metadata
-        REQUIRE(sn01InContract.leaveRequestTimestamp == 0);
-
-        std::string stakingRequirementHex = utils::padTo32Bytes(utils::decimalToHex(ServiceNodeRewardsContract::STAKING_REQUIREMENT));
-        INFO("Staking requirement did not match, ours was '" << stakingRequirementHex
-             << "'. The contract reported '" << sn01InContract.deposit
-             << "': Check if scripts/deploy-local-testnet.js requirement matches the hardcoded staking amount at ServiceNodeRewardsContract::STAKING_REQUIREMENT.");
-        REQUIRE(sn01InContract.deposit == stakingRequirementHex);
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Add several public keys to the smart contract and check aggregate pubkey" ) {
@@ -98,7 +147,10 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
             REQUIRE(provider->transactionSuccessful(hash));
         }
         REQUIRE(rewards_contract.serviceNodesLength() == 2);
-        REQUIRE(rewards_contract.aggregatePubkey() == "0x" + snl.aggregatePubkeyHex());
+        REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Add several public keys to the smart contract and liquidate one of them with everyone signing (including the liquidated node)" ) {
@@ -120,7 +172,10 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         REQUIRE(provider->transactionSuccessful(hash));
         REQUIRE(rewards_contract.serviceNodesLength() == 2);
         snl.deleteNode(service_node_to_remove);
-        REQUIRE(rewards_contract.aggregatePubkey() == "0x" + snl.aggregatePubkeyHex());
+        REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Add several public keys to the smart contract and liquidate one of them with a single non signer" ) {
@@ -142,7 +197,10 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         REQUIRE(provider->transactionSuccessful(hash));
         REQUIRE(rewards_contract.serviceNodesLength() == 2);
         snl.deleteNode(service_node_to_remove);
-        REQUIRE(rewards_contract.aggregatePubkey() == "0x" + snl.aggregatePubkeyHex());
+        REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Add several public keys to the smart contract and try liquidate one of them with a not enough signers" ) {
@@ -161,7 +219,10 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         tx = rewards_contract.liquidateBLSPublicKeyWithSignature(service_node_to_remove, pubkey, sig, {});
         REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
         REQUIRE(rewards_contract.serviceNodesLength() == 3);
-        REQUIRE(rewards_contract.aggregatePubkey() == "0x" + snl.aggregatePubkeyHex());
+        REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Initiate remove public key with correct signer" ) {
@@ -178,6 +239,9 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         REQUIRE(hash != "");
         REQUIRE(provider->transactionSuccessful(hash));
         REQUIRE(rewards_contract.serviceNodesLength() == 3);
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Initiate remove public key with incorrect signer" ) {
@@ -193,6 +257,9 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         std::vector<unsigned char> badseckey = utils::fromHexString(std::string(config.ADDITIONAL_PRIVATE_KEY1));
         REQUIRE_THROWS(signer.sendTransaction(tx, badseckey));
         REQUIRE(rewards_contract.serviceNodesLength() == 3);
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Remove public key after wait time should fail if node hasn't initiated removal" ) {
@@ -207,6 +274,9 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         tx = rewards_contract.removeBLSPublicKeyAfterWaitTime(service_node_to_remove);
         REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
         REQUIRE(rewards_contract.serviceNodesLength() == 3);
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Remove public key after wait time should fail if not enough time has passed since node initiated removal" ) {
@@ -225,6 +295,9 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         tx = rewards_contract.removeBLSPublicKeyAfterWaitTime(service_node_to_remove);
         REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
         REQUIRE(rewards_contract.serviceNodesLength() == 3);
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Remove public key after wait time should succeed if enough time has passed since node initiated removal" ) {
@@ -248,7 +321,10 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         REQUIRE(provider->transactionSuccessful(hash));
         REQUIRE(rewards_contract.serviceNodesLength() == 2);
         snl.deleteNode(service_node_to_remove);
-        REQUIRE(rewards_contract.aggregatePubkey() == "0x" + snl.aggregatePubkeyHex());
+        REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Add several public keys to the smart contract and remove one of them with a single non signer" ) {
@@ -270,7 +346,10 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         REQUIRE(provider->transactionSuccessful(hash));
         REQUIRE(rewards_contract.serviceNodesLength() == 2);
         snl.deleteNode(service_node_to_remove);
-        REQUIRE(rewards_contract.aggregatePubkey() == "0x" + snl.aggregatePubkeyHex());
+        REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Add several public keys to the smart contract and try remove one of them not enough signers" ) {
@@ -289,7 +368,10 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         tx = rewards_contract.removeBLSPublicKeyWithSignature(service_node_to_remove, pubkey, sig, non_signers);
         REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
         REQUIRE(rewards_contract.serviceNodesLength() == 3);
-        REQUIRE(rewards_contract.aggregatePubkey() == "0x" + snl.aggregatePubkeyHex());
+        REQUIRE(rewards_contract.aggregatePubkeyString() == "0x" + snl.aggregatePubkeyHex());
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Add several public keys to the smart contract and update the rewards of one of them" ) {
@@ -315,6 +397,9 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         recipient = rewards_contract.viewRecipientData(senderAddress);
         REQUIRE(recipient.rewards == recipientAmount);
         REQUIRE(recipient.claimed == 0);
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Add several public keys to the smart contract and update the rewards without enough signers and expect fail" ) {
@@ -335,6 +420,9 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         const auto non_signers = snl.findNonSigners(signers);
         tx = rewards_contract.updateRewardsBalance(senderAddress, recipientAmount, sig, non_signers);
         REQUIRE_THROWS(signer.sendTransaction(tx, seckey));
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Add several public keys to the smart contract and update the rewards of one of them and successfully claim the rewards" ) {
@@ -368,6 +456,9 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         auto recipient = rewards_contract.viewRecipientData(recipientAddress);
         REQUIRE(recipient.rewards == recipientAmount);
         REQUIRE(recipient.claimed == amount);
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 
     SECTION( "Add LOTS of public keys to the smart contract and update the rewards of one of them and successfully claim the rewards" ) {
@@ -407,5 +498,8 @@ TEST_CASE( "Rewards Contract", "[ethereum]" ) {
         auto recipient = rewards_contract.viewRecipientData(recipientAddress);
         REQUIRE(recipient.rewards == recipientAmount);
         REQUIRE(recipient.claimed == amount);
+
+        verifyEVMServiceNodesAgainstCPPState(snl);
+        resetContractToSnapshot();
     }
 }

--- a/test/cpp/test/src/rewards_contract.cpp
+++ b/test/cpp/test/src/rewards_contract.cpp
@@ -67,7 +67,8 @@ static void verifyEVMServiceNodesAgainstCPPState(const ServiceNodeList& snl)
         }
 
         // NOTE: Verify metadata
-        REQUIRE(ethNode.leaveRequestTimestamp == 0);
+        // TODO: Synchronise leave request timestamp into C++ representation
+        // REQUIRE(ethNode.leaveRequestTimestamp == 0);
 
         // NOTE: Verify BLS key on the contract matches the C++ key
         REQUIRE(ethNode.pubkey == cppNode.getPublicKey());


### PR DESCRIPTION
Depends on https://github.com/darcys22/eth-sn-contracts/pull/1 being merged

Currently the service node list in the smart contract is managed by
a circular linked list where LIST_END (U64_MAX) is reserved as the head
of the linked list. We also reserve slot 0 (by setting nextServiceNodeID to 1)
and make it unallocatable.

We can avoid wasting a slot by placing a sentinel at slot 0. The logic
plays out similarly in that the sentinel points to itself as if it were
circular.

In addition to that, since it's a doubly linked-list, there are common patterns
used to assign and delete from the list that I've opted for. These patterns
simplify the code in our instance, `seedPublicKeyList` was declaring various
temporary variables to track list state which were not necessary.

I've wrapped the append and delete from list into functions with the equivalent
pattern as you would see it in C++ code, e.g.

```
func serviceNodeAdd(...) {
    // The following is the insertion pattern in a doubly-linked list
    // with sentinel at index 0
    //
    // ```c
    // node->next       = sentinel;
    // node->prev       = sentinel->prev;
    // node->next->prev = node;
    // node->prev->next = node;
    // ```
    ...
}
```

I've added unit tests to verify the state of the service node list and
its pointed-ness matches what we manually derived in C++'s ServiceNodeList
with the new service node functionality exposed in C++.