### PR TITLE
Fix onlyOperator w/tx.origin allowing auth to be bypassed

### DIFF
--- a/contracts/ServiceNodeContribution.sol
+++ b/contracts/ServiceNodeContribution.sol
@@ -41,7 +41,7 @@ contract ServiceNodeContribution is Shared{
 
     // MODIFIERS
     modifier onlyOperator() {
-        require(tx.origin == operator, "Only the operator can perform this action.");
+        require(msg.sender == operator, "Only the operator can perform this action.");
         _;
     }
     
@@ -61,12 +61,12 @@ contract ServiceNodeContribution is Shared{
         nzUint(_maxContributors)
     {
         stakingRewardsContract = IServiceNodeRewards(_stakingRewardsContract);
-        SENT = IERC20(stakingRewardsContract.designatedToken());
-        stakingRequirement = stakingRewardsContract.stakingRequirement();
-        maxContributors = _maxContributors;
-        operator = tx.origin;
-        blsPubkey = _blsPubkey;
-        serviceNodeParams = _serviceNodeParams;
+        SENT                   = IERC20(stakingRewardsContract.designatedToken());
+        stakingRequirement     = stakingRewardsContract.stakingRequirement();
+        maxContributors        = _maxContributors;
+        operator               = tx.origin; // NOTE: Creation is delegated by operator through factory
+        blsPubkey              = _blsPubkey;
+        serviceNodeParams      = _serviceNodeParams;
     }
 
 

--- a/contracts/test/TestModifierOnlyOperatorViaProxyContract.sol
+++ b/contracts/test/TestModifierOnlyOperatorViaProxyContract.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.20;
+
+interface IServiceNodeContribution {
+    function cancelNode() external;
+}
+
+// NOTE: Ensures that we cannot bypass `onlyOperator` by baiting a service node
+// operator to execute an unrelated contract which forwards the interaction
+// to the contribution contract (e.g. check we are not using tx.origin for
+// authentication).
+//
+// See: https://docs.soliditylang.org/en/v0.8.20/security-considerations.html#tx-origin
+
+contract TestModifierOnlyOperatorViaProxyContract {
+    IServiceNodeContribution public immutable snContributionContract;
+
+    constructor(address contractAddress) {
+        snContributionContract = IServiceNodeContribution(contractAddress);
+    }
+
+    function proxyCancelNode() external {
+        snContributionContract.cancelNode();
+    }
+}
+


### PR DESCRIPTION
You can maliciously construct a tx.origin that is the operator by getting them to interact with a malicious contract which then forwards the request to the target contract.

In our instance, this allows someone else to finalize or cancel the node on behalf of the operator which is a mild inconvenience but one that we can block by checking `msg.sender` instead of `tx.origin`.

We note that `tx.origin` is necessary in the constructor because the intended workflow is to create a contract through the contribution factory (which allows applications to enumerate service nodes accepting contribution by parsing the logs of that contract) in which case the original address of the TX that interacted with the factory is identified as the service node operator.